### PR TITLE
feat: backtrack and fast forward 5s and play/pause audio

### DIFF
--- a/src/screens/AudioScreen.tsx
+++ b/src/screens/AudioScreen.tsx
@@ -31,8 +31,8 @@ const AudioScreen = ({ navigation }): JSX.Element => {
   const audioLength = audio.getDuration()
 
   const handleSliderChange = (value: number) => {
-    // progress.value = value
-    // audio.setCurrentTime(progress.value)
+    progress.value = value
+    audio.setCurrentTime(progress.value)
   }
 
   const handlePlayPause = () => {
@@ -52,7 +52,7 @@ const AudioScreen = ({ navigation }): JSX.Element => {
 
   const trackCurrentAudioTime = () => {
     const intervalId = setInterval(() => {
-      audio.getCurrentTime((seconds, isPlay) => {
+      audio.getCurrentTime((seconds) => {
         progress.value = seconds;
         setPercentComplete((seconds / audioLength) * 100);
       });
@@ -61,8 +61,7 @@ const AudioScreen = ({ navigation }): JSX.Element => {
   }
 
   const stopTrackingCurrentAudioTime = () => {
-    const intervalId = intervalRef.current;
-    clearInterval(intervalId);
+    clearInterval(intervalRef.current);
   }
   
   const playbackSpeeds = [0.5, 1, 1.5, 2]
@@ -77,27 +76,29 @@ const AudioScreen = ({ navigation }): JSX.Element => {
   }
 
   const goBack = () => {
-    stopTrackingCurrentAudioTime()
-    if (progress.value >= 5) {
-      progress.value =  progress.value - 5
-      audio.setCurrentTime(progress.value - 5)
-    } else {
-      progress.value = 0
-      audio.setCurrentTime(0)
-    }
-    trackCurrentAudioTime()
+    audio.getCurrentTime((seconds) => {
+      let newTime = 0;
+      if (seconds - 2 < 0)
+        newTime = 0;
+      else
+        newTime = seconds - 2;
+      audio.setCurrentTime(newTime)
+      progress.value = newTime
+      setPercentComplete((newTime / audioLength) * 100);
+    })
   }
 
   const goForward = () => {
-    stopTrackingCurrentAudioTime()
-    if (progress.value <= audioLength - 5) {
-      progress.value = progress.value + 5
-      audio.setCurrentTime(progress.value + 5)
-    } else {
-      progress.value = audioLength
-      audio.setCurrentTime(audioLength)
-    }
-    trackCurrentAudioTime()
+    audio.getCurrentTime((seconds) => {
+      let newTime = 0;
+      if (seconds + 2 > audioLength)
+        newTime = audioLength;
+      else
+        newTime = seconds + 2;
+      audio.setCurrentTime(newTime)
+      progress.value = newTime
+      setPercentComplete((newTime / audioLength) * 100);
+    })
   }
   
   return (

--- a/src/screens/AudioScreen.tsx
+++ b/src/screens/AudioScreen.tsx
@@ -1,20 +1,70 @@
-import React, {useState, useEffect} from 'react'
-import {Text, View, TouchableOpacity, Image, StyleSheet} from 'react-native'
-import {Slider} from '@react-native-assets/slider'
-import { GestureHandlerRootView } from 'react-native-gesture-handler'
+import React, { useEffect, useRef, useState } from 'react';
+import { Image, Text, TouchableOpacity, View } from 'react-native';
+import { Slider } from 'react-native-awesome-slider';
+import RNFS from 'react-native-fs';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { useSharedValue } from 'react-native-reanimated';
+import Sound from 'react-native-sound';
+import styles from '../styles/audioScreen';
+
+Sound.setCategory('Playback');
+
+// fetch audio file
+var audio = new Sound('hello.wav', RNFS.DocumentDirectoryPath, (error) => {
+  if (error) {
+    console.log('failed to load the sound', error.message);
+    return;
+  }
+  // loaded successfully
+});
 
 const AudioScreen = ({ navigation }): JSX.Element => {
   //TODO: Dynamically load the image and text
   const playerImageURL =
     'https://s3-alpha-sig.figma.com/img/50dc/8a30/5e43c25c1cefdfb51be8639c30d04b57?Expires=1699228800&Signature=SpBEk3Xt0lHZkppm21uyJK~2V1pu2m4EBkw251xpCmkSaFIVtEYyQCRxJysuBDoTn00htErWfTzj5FPAan3wn2cdY4MsFMSJk0EdZW8GXunVjuW~icCloGP6NSHheReOL0dLKKy0bXireuXyQbF~sFrRNmdlrLVUhAS6YWCVm9372cL~XbMwihiXVRgTane8dCH~yqSiKJhEvHDZGOaNd3xpmHjpruNlkPAa3Uy26YLwpv-R9rc5OWFb27jSdlaRsmPa0msAylLtYZqME6prIcM-tEb-ckjL-404IIr~h6X-MtqZha2x~ZLssZbyKNPvYCsclqJiNQenkfYYKDY4dg__&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4'
   const playerText = 'Neoclassicism And Early Romanticism In Britain'
-  const audioLength = 100
+  
+  const [isPlaying, setIsPlaying] = useState(false);  //initialised to false
+  const [percentComplete, setPercentComplete] = useState(0);
+  const progress = useSharedValue(0)
+  const intervalRef = useRef(setInterval(()=>{}));
+  const audioLength = audio.getDuration()
 
-  const [sliderValue, setSliderValue] = useState(0)
   const handleSliderChange = (value: number) => {
-    setSliderValue(value)
+    // progress.value = value
+    // audio.setCurrentTime(progress.value)
   }
 
+  const handlePlayPause = () => {
+    if (isPlaying) {
+      audio.pause();
+      stopTrackingCurrentAudioTime();
+    }else{
+      audio.setVolume(10);
+      audio.play(success => {
+        stopTrackingCurrentAudioTime()
+        setIsPlaying(false)
+      });
+      trackCurrentAudioTime()
+    }
+    setIsPlaying(!isPlaying);
+  }
+
+  const trackCurrentAudioTime = () => {
+    const intervalId = setInterval(() => {
+      audio.getCurrentTime((seconds, isPlay) => {
+        progress.value = seconds;
+        setPercentComplete((seconds / audioLength) * 100);
+      });
+    }, 10);
+    intervalRef.current = intervalId;
+  }
+
+  const stopTrackingCurrentAudioTime = () => {
+    const intervalId = intervalRef.current;
+    clearInterval(intervalId);
+  }
+  
   const playbackSpeeds = [0.5, 1, 1.5, 2]
   const maxSpeedIndex = playbackSpeeds.length - 1
   const [playbackSpeed, setPlaybackSpeed] = useState(playbackSpeeds[1]) //default it to 1x speed
@@ -26,6 +76,30 @@ const AudioScreen = ({ navigation }): JSX.Element => {
     setPlaybackSpeed(playbackSpeeds[nextSpeedIndex])
   }
 
+  const goBack = () => {
+    stopTrackingCurrentAudioTime()
+    if (progress.value >= 5) {
+      progress.value =  progress.value - 5
+      audio.setCurrentTime(progress.value - 5)
+    } else {
+      progress.value = 0
+      audio.setCurrentTime(0)
+    }
+    trackCurrentAudioTime()
+  }
+
+  const goForward = () => {
+    stopTrackingCurrentAudioTime()
+    if (progress.value <= audioLength - 5) {
+      progress.value = progress.value + 5
+      audio.setCurrentTime(progress.value + 5)
+    } else {
+      progress.value = audioLength
+      audio.setCurrentTime(audioLength)
+    }
+    trackCurrentAudioTime()
+  }
+  
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <View style={styles.background}>
@@ -44,15 +118,18 @@ const AudioScreen = ({ navigation }): JSX.Element => {
         <View style={styles.audioPlayerContainer}>
           <Slider
             style={styles.sliderStyle}
-            minimumValue={0}
-            maximumValue={audioLength}
-            minimumTrackTintColor="white"
-            thumbTintColor="white"
-            value={sliderValue}
+            progress={progress}
+            minimumValue={useSharedValue(0)}
+            maximumValue={useSharedValue(audioLength)}
+            theme={{
+              minimumTrackTintColor: '#fff',
+              bubbleBackgroundColor: '#666',
+              maximumTrackTintColor: '#1B3340',
+            }}
             onValueChange={handleSliderChange}
           />
           <Text style={styles.textStyle}>
-            {((sliderValue / audioLength) * 100).toFixed(0)}%
+            {percentComplete.toFixed(0)}%
           </Text>
           <View style={styles.audioControllerContainer}>
             <TouchableOpacity onPress={() => {}}>
@@ -62,30 +139,20 @@ const AudioScreen = ({ navigation }): JSX.Element => {
               />
             </TouchableOpacity>
             <TouchableOpacity
-              onPress={() => {
-                if (sliderValue >= 5) {
-                  setSliderValue(sliderValue - 5)
-                } else {
-                  setSliderValue(0)
-                }
-              }}>
+              onPress={goBack}>
               <Image
                 source={require('../assets/gobackward.png')}
                 style={styles.buttonStyle}
               />
             </TouchableOpacity>
-            <TouchableOpacity onPress={() => {}}>
+            <TouchableOpacity onPress={handlePlayPause}>
               <Image
                 source={require('../assets/play.jpg')}
                 style={styles.playerButtonStyle}
               />
             </TouchableOpacity>
             <TouchableOpacity
-              onPress={() => {
-                if (sliderValue + 5 <= audioLength) {
-                  setSliderValue(sliderValue + 5)
-                }
-              }}>
+              onPress={goForward}>
               <Image
                 source={require('../assets/goforward.png')}
                 style={styles.buttonStyle}
@@ -119,77 +186,5 @@ const AudioScreen = ({ navigation }): JSX.Element => {
     </GestureHandlerRootView>
   )
 }
-
-const styles = StyleSheet.create({
-  background: {
-    flex: 1,
-    alignItems: 'center',
-    backgroundColor: '#121A2E',
-  },
-  navContainer: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    paddingTop: 40,
-    paddingLeft: 20,
-  },
-  audioDetailContainer: {
-    marginTop: 110,
-    alignItems: 'center',
-  },
-  audioPlayerContainer: {
-    marginTop: 20,
-  },
-  audioControllerContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  preferencesContainer: {
-    marginTop: 10,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  buttonStyle: {
-    width: 25,
-    height: 25,
-  },
-  playerButtonStyle: {
-    width: 70,
-    height: 70,
-  },
-  audioTitleStyle: {
-    color: '#FFF',
-    textAlign: 'center',
-    fontFamily: 'Manrope',
-    fontSize: 20,
-    fontStyle: 'normal',
-    fontWeight: '700',
-    lineHeight: 30,
-    marginTop: 20,
-    paddingHorizontal: 50,
-  },
-  playerImageStyle: {
-    width: 200,
-    height: 200,
-  },
-  sliderStyle: {
-    width: 300,
-    height: 40,
-  },
-  textStyle: {
-    color: '#FFF',
-    fontFamily: 'Manrope',
-    fontWeight: 'bold',
-  },
-  subTextStyle: {
-    color: '#FFF',
-    fontFamily: 'Manrope',
-    fontWeight: 'bold',
-    fontSize: 9,
-    paddingTop: 5,
-  },
-})
 
 export default AudioScreen

--- a/src/screens/AudioScreen.tsx
+++ b/src/screens/AudioScreen.tsx
@@ -29,11 +29,12 @@ const AudioScreen = ({ navigation }): JSX.Element => {
   const progress = useSharedValue(0)
   const intervalRef = useRef(setInterval(()=>{}));
   const audioLength = audio.getDuration()
+  const offset = 5; //seconds
 
-  const handleSliderChange = (value: number) => {
-    progress.value = value
-    audio.setCurrentTime(progress.value)
-  }
+  // const handleSliderChange = (value: number) => {
+    // progress.value = value
+    // audio.setCurrentTime(progress.value)
+  // }
 
   const handlePlayPause = () => {
     if (isPlaying) {
@@ -78,10 +79,10 @@ const AudioScreen = ({ navigation }): JSX.Element => {
   const goBack = () => {
     audio.getCurrentTime((seconds) => {
       let newTime = 0;
-      if (seconds - 2 < 0)
+      if (seconds - offset < 0)
         newTime = 0;
       else
-        newTime = seconds - 2;
+        newTime = seconds - offset;
       audio.setCurrentTime(newTime)
       progress.value = newTime
       setPercentComplete((newTime / audioLength) * 100);
@@ -91,10 +92,10 @@ const AudioScreen = ({ navigation }): JSX.Element => {
   const goForward = () => {
     audio.getCurrentTime((seconds) => {
       let newTime = 0;
-      if (seconds + 2 > audioLength)
+      if (seconds + offset > audioLength)
         newTime = audioLength;
       else
-        newTime = seconds + 2;
+        newTime = seconds + offset;
       audio.setCurrentTime(newTime)
       progress.value = newTime
       setPercentComplete((newTime / audioLength) * 100);
@@ -127,7 +128,7 @@ const AudioScreen = ({ navigation }): JSX.Element => {
               bubbleBackgroundColor: '#666',
               maximumTrackTintColor: '#1B3340',
             }}
-            onValueChange={handleSliderChange}
+            // onValueChange={handleSliderChange}
           />
           <Text style={styles.textStyle}>
             {percentComplete.toFixed(0)}%

--- a/src/styles/audioScreen.jsx
+++ b/src/styles/audioScreen.jsx
@@ -1,0 +1,76 @@
+import { StyleSheet } from 'react-native'
+
+const styles = StyleSheet.create({
+  background: {
+    flex: 1,
+    alignItems: 'center',
+    backgroundColor: '#121A2E',
+  },
+  navContainer: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    paddingTop: 40,
+    paddingLeft: 20,
+  },
+  audioDetailContainer: {
+    marginTop: 110,
+    alignItems: 'center',
+  },
+  audioPlayerContainer: {
+    flex: 1,
+    marginTop: 20,
+  },
+  audioControllerContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  preferencesContainer: {
+    marginTop: 10,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  buttonStyle: {
+    width: 25,
+    height: 25,
+  },
+  playerButtonStyle: {
+    width: 70,
+    height: 70,
+  },
+  audioTitleStyle: {
+    color: '#FFF',
+    textAlign: 'center',
+    fontFamily: 'Manrope',
+    fontSize: 20,
+    fontStyle: 'normal',
+    fontWeight: '700',
+    lineHeight: 30,
+    marginTop: 20,
+    paddingHorizontal: 50,
+  },
+  playerImageStyle: {
+    width: 200,
+    height: 200,
+  },
+  sliderStyle: {
+    width: 300,
+    height: 40,
+  },
+  textStyle: {
+    color: '#FFF',
+    fontFamily: 'Manrope',
+    fontWeight: 'bold',
+  },
+  subTextStyle: {
+    color: '#FFF',
+    fontFamily: 'Manrope',
+    fontWeight: 'bold',
+    fontSize: 9,
+    paddingTop: 5,
+  },
+})
+
+export default styles;


### PR DESCRIPTION
resolves: https://trello.com/c/MaIc1ULy/15-connect-sound-library-with-audio-screen-ui

### Description
- Copied import audio file from file system code to Audio Screen.
- Play and pause audio and control fast forward and backtrack with control buttons.
- Show progress on slider and percentage done.

### How?
- the slider values range from 0 to length of audio, so the slider value corresponds to the audio progress.
- to fast forward or backtrack, set the current time to the new time and update the slider value and percentage on the screen.
- there's a timer where every 10 ms it records the current time in seconds and sets the slider value to that.

### Todo
- Seek by dragging slider. The code for sliding has been commented out because there's more cases to handle before it can work.
- Speedup audio by x time.


https://github.com/yili288/readease/assets/47297703/b15e335a-df62-4a72-8a88-eb2fbedc7f56